### PR TITLE
lat_fifo: break writer when read/write failed

### DIFF
--- a/src/lat_fifo.c
+++ b/src/lat_fifo.c
@@ -160,6 +160,7 @@ writer(register int w, register int r)
 		if (read(r, cptr, 1) != 1 ||
 			write(w, cptr, 1) != 1) {
 			    perror("(w) read/write on pipe");
+				break;
 		}
 	}
 }


### PR DESCRIPTION
The `lat_fifo` benchmark will fail in Linux when in the `cleanup` procedure. The cause is that the `writer` thread failed to be killed and the FIFO file was removed. This PR breaks the writer thread when read/write fails and won't affect the test result.