### PR TITLE
Replace localhost and 0.0.0.0 with 127.0.0.1

### DIFF
--- a/src/lat_select.c
+++ b/src/lat_select.c
@@ -147,7 +147,7 @@ server(void* cookie)
 int
 open_socket(void* cookie)
 {
-	return tcp_connect("localhost", TCP_SELECT, SOCKOPT_NONE);
+	return tcp_connect("127.0.0.1", TCP_SELECT, SOCKOPT_NONE);
 }
 
 int

--- a/src/lib_tcp.c
+++ b/src/lib_tcp.c
@@ -29,6 +29,9 @@ tcp_server(int prog, int rdwr)
 	}
 	sock_optimize(sock, rdwr);
 	bzero((void*)&s, sizeof(s));
+
+	// Change to 127.0.0.1 instead of 0.0.0.0
+	s.sin_addr.s_addr = 0x0100007f;
 	s.sin_family = AF_INET;
 	if (prog < 0) {
 		s.sin_port = htons(-prog);

--- a/src/lib_udp.c
+++ b/src/lib_udp.c
@@ -27,6 +27,8 @@ udp_server(u_long prog, int rdwr)
 	sock_optimize(sock, rdwr);
 	bzero((void*)&s, sizeof(s));
 	s.sin_family = AF_INET;
+	// Change to 127.0.0.1 instead of 0.0.0.0
+	s.sin_addr.s_addr = 0x0100007f;
 #ifdef	NO_PORTMAPPER
 	s.sin_port = htons(prog);
 #endif


### PR DESCRIPTION
This PR will enable Asterinas to run `bw_tcp`, `lat_tcp`, `lat_udp`, `lat_select tcp` and `lat_connect` to test the loopback network device.