### PR TITLE
Don't exit after partial send

### DIFF
--- a/src/bw_tcp.c
+++ b/src/bw_tcp.c
@@ -242,10 +242,23 @@ source(int data)
 	/*
 	 * Keep sending messages until the connection is closed
 	 */
-	while (write(data, buf, m) == m) {
-#ifdef	TOUCH
-		touch(buf, m);
+	writer(data, buf, m);
+}
+
+void
+writer(int writefd, char* buf, size_t xfer)
+{
+	size_t	done;
+	ssize_t	n;
+
+	for ( ;; ) {
+#ifdef TOUCH
+		touch(buf, xfer);
 #endif
+		for (done = 0; done < xfer; done += n) {
+			if ((n = write(writefd, buf, xfer - done)) < 0) {
+				exit(0);
+			}
+		}
 	}
-	free(buf);
 }


### PR DESCRIPTION
`bw_tcp` will exit if the `send` system call could not send the whole message.
https://github.com/asterinas/lmbench/blob/d2b295043d8ec2794293293e3f1039b2dd5dd64f/src/bw_tcp.c#L242-L250

This seems to be buggy, since the `send` system call does not guarantee that the whole message will be sent.

In this PR, I copy the `writer` method from `bw_pipe` and use it in `bw_tcp`:
https://github.com/asterinas/lmbench/blob/d2b295043d8ec2794293293e3f1039b2dd5dd64f/src/bw_pipe.c#L116-L132