### PR TITLE
Make lat_tcp accept server address as parameter

### DIFF
--- a/src/bw_tcp.c
+++ b/src/bw_tcp.c
@@ -181,7 +181,7 @@ server_main()
 
 	GO_AWAY;
 
-	data = tcp_server(TCP_DATA, SOCKOPT_WRITE|SOCKOPT_REUSE);
+	data = tcp_server("127.0.0.1", TCP_DATA, SOCKOPT_WRITE|SOCKOPT_REUSE);
 	if (data < 0) {
 		perror("server socket creation");
 		exit(1);

--- a/src/lat_connect.c
+++ b/src/lat_connect.c
@@ -97,7 +97,7 @@ server_main()
 	char	c ='1';
 
 	GO_AWAY;
-	sock = tcp_server(TCP_CONNECT, SOCKOPT_NONE|SOCKOPT_REUSE);
+	sock = tcp_server("127.0.0.1", TCP_CONNECT, SOCKOPT_NONE|SOCKOPT_REUSE);
 	for (;;) {
 		newsock = tcp_accept(sock, SOCKOPT_NONE);
 		if (read(newsock, &c, 1) > 0) {

--- a/src/lat_select.c
+++ b/src/lat_select.c
@@ -119,7 +119,7 @@ server(void* cookie)
 	}
 
 	/* Create a socket for clients to connect to */
-	state->sock = tcp_server(TCP_SELECT, SOCKOPT_REUSE);
+	state->sock = tcp_server("127.0.0.1", TCP_SELECT, SOCKOPT_REUSE);
 	if (state->sock <= 0) {
 		perror("lat_select: Could not open tcp server socket");
 		exit(1);

--- a/src/lib_tcp.c
+++ b/src/lib_tcp.c
@@ -15,13 +15,13 @@
  * XXX - it would be nice if you could advertise ascii strings.
  */
 int
-tcp_server(int prog, int rdwr)
+tcp_server(char* addr, int prog, int rdwr)
 {
 	int	sock;
 	struct	sockaddr_in s;
 
 #ifdef	LIBTCP_VERBOSE
-	fprintf(stderr, "tcp_server(%u, %u)\n", prog, rdwr);
+	fprintf(stderr, "tcp_server(%s, %u, %u)\n", addr, prog, rdwr);
 #endif
 	if ((sock = socket(AF_INET, SOCK_STREAM, IPPROTO_TCP)) < 0) {
 		perror("socket");
@@ -30,8 +30,10 @@ tcp_server(int prog, int rdwr)
 	sock_optimize(sock, rdwr);
 	bzero((void*)&s, sizeof(s));
 
-	// Change to 127.0.0.1 instead of 0.0.0.0
-	s.sin_addr.s_addr = 0x0100007f;
+	if (inet_aton(addr, &s.sin_addr) < 0) {
+		fprintf(stderr, "inet_aton cannot parse %s", addr);
+		exit(1);
+	}
 	s.sin_family = AF_INET;
 	if (prog < 0) {
 		s.sin_port = htons(-prog);

--- a/src/lib_tcp.h
+++ b/src/lib_tcp.h
@@ -4,7 +4,7 @@
 #include	<netdb.h>
 #include	<arpa/inet.h>
 
-int	tcp_server(int prog, int rdwr);
+int	tcp_server(char* addr, int prog, int rdwr);
 int	tcp_done(int prog);
 int	tcp_accept(int sock, int rdwr);
 int	tcp_connect(char *host, int prog, int rdwr);

--- a/src/lmhttp.c
+++ b/src/lmhttp.c
@@ -80,7 +80,7 @@ main(int ac, char **av)
 	 * Steve - why is this here?
 	 */
 	signal(SIGPIPE, SIG_IGN);
-	data = tcp_server(prog, SOCKOPT_REUSE);
+	data = tcp_server("127.0.0.1", prog, SOCKOPT_REUSE);
 	bufs[0] = valloc(XFERSIZE);
 	bufs[1] = valloc(XFERSIZE);
 	bufs[2] = valloc(XFERSIZE);


### PR DESCRIPTION
This PR makes `lat_tcp` accept server address as parameter, so `lat_tcp` can work for both localhost and virtio-net. 

This PR also makes some small modifications to makes the test program exit early if some error occurs.