### PR TITLE
Fix: Ensure SIGTERM signal terminates lat_fifo benchmark child process

### DIFF
--- a/src/lat_fifo.c
+++ b/src/lat_fifo.c
@@ -89,6 +89,7 @@ initialize(iter_t iterations, void *cookie)
 	switch (state->pid = fork()) {
 	    case 0:
 		handle_scheduler(benchmp_childid(), 1, 1);
+		signal(SIGTERM, exit);
 		state->rd = open(state->filename1, O_RDONLY);
 		state->wr = open(state->filename2, O_WRONLY);
 		writer(state->wr, state->rd);


### PR DESCRIPTION
This could fix https://github.com/asterinas/asterinas/issues/2762, and the error occurs on both Asterinas and Linux systems.